### PR TITLE
Fix typo in Crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Wayne Nilsen <waynenilsen@gmail.com>"]
 name = "handlebars-markdown-helper"
 version = "0.1.2"
-description = "A helper for handlebars that adds markdown renedring"
+description = "A helper for handlebars that adds markdown rendering"
 license = "MIT"
 homepage = "https://github.com/waynenilsen/handlebars-markdown-helper"
 readme = "README.md"


### PR DESCRIPTION
Also you probably shouldn't put the `Cargo.lock` here.
The official recommendation:

> If you're building a library, put Cargo.lock in your .gitignore.
> (from http://doc.crates.io/guide.html#cargotoml-vs-cargolock)

This way users of this library will get whatever is the newest supported version of dependencies instead of the fixed ones.
